### PR TITLE
Added CreateChargeWithToken method so a card number does not need to be passed in

### DIFF
--- a/src/StripeClient.Charges.cs
+++ b/src/StripeClient.Charges.cs
@@ -8,7 +8,32 @@ namespace Stripe
 {
 	public partial class StripeClient
 	{
-		public StripeObject CreateCharge(decimal amount, string currency, string customerId, string description = null)
+        /// <summary>
+        /// Creates a charge using a token retrieved via the browser
+        /// </summary>
+        /// <returns></returns>
+        public StripeObject CreateChargeWithToken(decimal amount, string token, string currency="usd", string description = null)
+        {
+            Require.Argument("amount", amount);
+            Require.Argument("currency", currency);
+            Require.Argument("token", token);
+
+            if (amount < 0.5M)
+                throw new ArgumentOutOfRangeException("amount", amount, "Amount must be at least 50 cents");
+
+            var request = new RestRequest();
+            request.Method = Method.POST;
+            request.Resource = "charges";
+
+            request.AddParameter("amount", Convert.ToInt32(amount * 100M));
+            request.AddParameter("currency", currency);
+            request.AddParameter("card", token);
+            if (description.HasValue()) request.AddParameter("description", description);
+
+            return ExecuteObject(request);
+        }
+        
+        public StripeObject CreateCharge(decimal amount, string currency, string customerId, string description = null)
 		{
 			Require.Argument("amount", amount);
 			Require.Argument("currency", currency);

--- a/test/Stripe.Tests/ChargeTests.cs
+++ b/test/Stripe.Tests/ChargeTests.cs
@@ -14,7 +14,7 @@ namespace Stripe.Tests
 		public ChargeTests()
 		{
 			_card = new CreditCard {
-				Number = "4111111111111111",
+				Number = "4242 4242 4242 4242",
 				ExpMonth = 3,
 				ExpYear = 2015
 			};
@@ -22,7 +22,15 @@ namespace Stripe.Tests
 			_client = new StripeClient(Constants.ApiKey);
 			_customer = _client.CreateCustomer(_card);
 		}
-
+        [Fact]
+        public void CreateCharge_Using_Token()
+        {
+            dynamic token = _client.CreateCardToken(_card);
+            dynamic response = _client.CreateChargeWithToken(100M,token.Id);
+            Assert.NotNull(response);
+            Assert.False(response.IsError);
+            Assert.True(response.Paid);
+        }
 		[Fact]
 		public void CreateCharge_Card_Test()
 		{


### PR DESCRIPTION
One of the main benefits of using Stripe is that it's powered by Javascript. This is more true these days with the Stripe Button (https://stripe.com/docs/button) - you **do not want** credit card information hitting your server in order to remain PCI compliant.

Stripe gets around this by giving you a "token" for the approved card that you can charge against. You send that token to your server to then CreateCharge against stripe.

That's what this pull request is and does - a test has been added to Stripe.Tests as well.

Cheers! And thanks for the library.
