### PR TITLE
Added OAuth Support

### DIFF
--- a/src/Stripe.csproj
+++ b/src/Stripe.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Web.Extensions" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="StripeClient.OAuth.cs" />
     <Compile Include="StripeClient.Accounts.cs" />
     <Compile Include="StripeClient.Events.cs" />
     <Compile Include="CreditCardToken.cs" />

--- a/src/StripeClient.OAuth.cs
+++ b/src/StripeClient.OAuth.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using RestSharp;
+using RestSharp.Validation;
+
+
+namespace Stripe
+{
+	public partial class StripeClient
+	{
+		public string CreateOAuthAuthorizationUrl(string clientId, string scope = "read_only", string landing = "login", string state = "")
+		{
+			if (string.IsNullOrWhiteSpace(clientId))
+			{
+				throw new ArgumentNullException("clientId");
+			}
+
+			var url = new StringBuilder();
+			url.Append(string.Format("https://connect.stripe.com/oauth/authorize?response_type=code&client_id={0}", clientId));
+
+			if (!string.IsNullOrWhiteSpace(scope))
+			{
+				url.Append(string.Format("&scope={0}", scope));
+			}
+
+			if (!string.IsNullOrWhiteSpace(landing))
+			{
+				url.Append(string.Format("&stripe_landing={0}", landing));
+			}
+
+			if (!string.IsNullOrWhiteSpace(state))
+			{
+				url.Append(string.Format("&state={0}", state));
+			}
+
+			return url.ToString();
+		}
+
+		public StripeObject RetrieveOAuthToken(string code)
+		{
+			Require.Argument("code", code);
+
+			var request = new RestRequest();
+			request.Method = Method.POST;
+			request.AddHeader("Authorization", string.Concat("Bearer ", this.ApiKey));
+			request.Resource = "oauth/token?code={code}&grant_type=authorization_code";
+			request.AddUrlSegment("code", code);
+
+			return ExecuteConnectObject(request);
+		}
+	}
+}

--- a/test/Stripe.Tests/OAuthTests.cs
+++ b/test/Stripe.Tests/OAuthTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+
+namespace Stripe.Tests
+{
+	public class OAuthTests
+	{
+		private StripeClient _client;
+
+		public OAuthTests()
+		{
+			_client = new StripeClient(Constants.ApiKey);
+		}
+
+		[Fact]
+		public void CreateOAuthAuthorizationUrl_Test()
+		{
+			string expected = "https://connect.stripe.com/oauth/authorize?response_type=code&client_id=clientId&scope=scope&stripe_landing=landing&state=state";
+			string actual = _client.CreateOAuthAuthorizationUrl("clientId", "scope", "landing", "state");
+
+			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
+		public void RetrieveOAuthToken_Test()
+		{
+			//todo: not sure how to test this
+		}
+	}
+}

--- a/test/Stripe.Tests/Stripe.Tests.csproj
+++ b/test/Stripe.Tests/Stripe.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="CardTokenTests.cs" />
     <Compile Include="AccountTests.cs" />
+    <Compile Include="OAuthTests.cs" />
     <Compile Include="EventTests.cs" />
     <Compile Include="InvoiceTests.cs" />
     <Compile Include="CouponTests.cs" />


### PR DESCRIPTION
This matches the `GET https://connect.stripe.com/oauth/authorize` and `POST https://connect.stripe.com/oauth/token` endpoints
- added CreateOAuthAuthorizationUrl method
- added CreateOAuthAuthorizationUrl unit test
- added RetrieveOAuthToken method

I wasnt sure how to unit test RetrieveOAuthToken, without going through the OAuth flow :cry:. I did execute the RetrieveOAuthToken method and verified that it worked locally.
