### PR TITLE
Fix example code in NuGet package

### DIFF
--- a/src/StripeExample.cs.pp
+++ b/src/StripeExample.cs.pp
@@ -14,7 +14,7 @@ namespace $rootnamespace$
 				Number = "4242424242424242",
 				ExpMonth = 3,
 				ExpYear = 2015,
-				Cvc = 123
+				Cvc = "123"
 			};
 
 			dynamic response = api.CreateCharge(


### PR DESCRIPTION
Change card number for a valid Stripe test card number.
Add CVC code to charge creation (as this is a required field for UK
Stripe accounts)
Change amount as although Stripe API is in cents, internally, amounts
are expressed in dollars.
Fix error handling as we need to check that IsError is false before we
can safely access the Paid boolean property.
