### PR TITLE
RestSharp Upgrade to 105.2

### DIFF
--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -21,8 +21,7 @@ using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Globalization;
-using RestSharp.Contrib;
-
+using RestSharp.Extensions.MonoHttp;
 
 namespace Stripe
 {

--- a/src/Stripe.csproj
+++ b/src/Stripe.csproj
@@ -44,9 +44,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RestSharp.105.0.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net4\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Stripe.nuspec
+++ b/src/Stripe.nuspec
@@ -15,7 +15,7 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<tags>stripe credit card payment gateway rest api .net40 .net45</tags>
 		<dependencies>
-			<dependency id="RestSharp" version="105.0.1" />
+			<dependency id="RestSharp" version="105.2.3" />
 		</dependencies>
 		<frameworkAssemblies>
 			<frameworkAssembly assemblyName="System.Core" targetFramework="net40" />

--- a/src/StripeAuthenticator.cs
+++ b/src/StripeAuthenticator.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using RestSharp;
 using System.Net;
+using RestSharp.Authenticators;
 
 namespace Stripe
 {

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.0.1" targetFramework="net40" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net4" />
 </packages>


### PR DESCRIPTION
RestSharp unfortunately made a breaking change in their minor release. This PR addresses #46 and upgrades the dependency to 105.2.3 or greater.